### PR TITLE
Deprecation warnings from psutil

### DIFF
--- a/pgactivity/UI.py
+++ b/pgactivity/UI.py
@@ -1207,11 +1207,11 @@ class UI:
 
                     proc.set_extra(
                         'mem_percent',
-                        proc.get_extra('psutil_proc').get_memory_percent())
+                        proc.get_extra('psutil_proc').memory_percent())
                     proc.set_extra(
                         'cpu_percent',
                         proc.get_extra('psutil_proc').\
-                            get_cpu_percent(interval=0))
+                            cpu_percent(interval=0))
                     new_procs[pid] = proc
                     procs.append({
                         'pid': pid,


### PR DESCRIPTION
psutil 2.1.1 is warning about deprecated functions get_memory_percent() and get_cpu_percent() in the header of the UI. This simply calls the functions as suggested by the warning.