### PR TITLE
Adds support for using pg_activity with Amazon RDS

### DIFF
--- a/pg_activity
+++ b/pg_activity
@@ -119,6 +119,13 @@ server activity monitoring.")
                 help = "Filesystem blocksize (default: 4096)",
                 metavar = 'BLOCKSIZE',
                 default = 4096)
+            # --rds
+            parser.add_option(
+                '--rds',
+                dest = 'rds',
+                action = 'store_true',
+                help = "Enable support for AWS RDS",
+                default = 'false')
             group = OptionGroup(
                 parser,
                 "Display Options, you can exclude some columns by using them ")
@@ -232,7 +239,8 @@ server activity monitoring.")
                     port = options.port,
                     user = options.username,
                     password = password,
-                    database = options.dbname)
+                    database = options.dbname,
+                    rds = options.rds)
                 break
             except psycopg2.OperationalError as err:
                 if nb_try < 1 and (err.pgcode == errorcodes.INVALID_PASSWORD or
@@ -278,7 +286,7 @@ server activity monitoring.")
         disp_procs = None
         delta_disk_io = None
         # get DB informations
-        db_info = PGAUI.data.pg_get_db_info(None)
+        db_info = PGAUI.data.pg_get_db_info(None, using_rds = options.rds)
         PGAUI.set_max_db_length(db_info['max_length'])
         # indentation
         indent = PGAUI.get_indent(flag)
@@ -305,7 +313,7 @@ server activity monitoring.")
                 delta_disk_io = PGAUI.data.get_global_io_counters()
             procs = new_procs
             # refresh the winodw
-            db_info = PGAUI.data.pg_get_db_info(db_info)
+            db_info = PGAUI.data.pg_get_db_info(db_info, using_rds = options.rds)
             PGAUI.set_max_db_length(db_info['max_length'])
             # bufferize
             PGAUI.set_buffer({

--- a/pg_activity
+++ b/pg_activity
@@ -240,7 +240,7 @@ server activity monitoring.")
                     user = options.username,
                     password = password,
                     database = options.dbname,
-                    rds = options.rds)
+                    rds_mode = options.rds)
                 break
             except psycopg2.OperationalError as err:
                 if nb_try < 1 and (err.pgcode == errorcodes.INVALID_PASSWORD or


### PR DESCRIPTION
Taken from the following blog post and fork:

http://blog.geesu.net/2015/06/09/using-pg_activity-with-amazon-rds/
https://github.com/Geesu/pg_activity/tree/feature/amazon-rds

Just adds this as an command line option instead of forcing it on all users.  Should maintain backwards compatibility with the previous functionality, just allows this to be used without errors when running against a remote RDS database.  All credit should go to @Geesu as he was the person that did the original legwork.

I can add documentation if you want, but I kept it minimal for now incase you would prefer a different approach to solving this problem.