### PR TITLE
Require python2. Fixes syntax errors on OS-es where "python" is python3.

### DIFF
--- a/pg_activity
+++ b/pg_activity
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 pg_activity


### PR DESCRIPTION
I'm using Arch Linux and the default python environment is python3. When trying to run pg_activity I get:

    File "./pg_activity", line 211
      except OptionParsingError, err:
                               ^
    SyntaxError: invalid syntax