### PR TITLE
process['database'] can be None for some maintenance processes

### DIFF
--- a/pgactivity/UI.py
+++ b/pgactivity/UI.py
@@ -1932,7 +1932,7 @@ class UI:
                         l_lineno,
                         colno,
                         PGTOP_COLS[self.mode]['database']['template_h'] % \
-                            (process['database'][:16],),
+                            (str(process['database'])[:16],),
                         self.line_colors['database'][typecolor])
         if self.mode == 'activities':
             if flag & PGTOP_FLAG_USER:


### PR DESCRIPTION
We use barman with wal shipping for PITR on our main database. This creates a
walsender process that is not connected to any specific database.