### PR TITLE
Doc update about system info + examples

### DIFF
--- a/docs/man/pg_activity.1
+++ b/docs/man/pg_activity.1
@@ -129,7 +129,7 @@
 .\" ========================================================================
 .\"
 .IX Title "PG_ACTIVITY 1"
-.TH PG_ACTIVITY 1 "2017-11-14" "pg_activity 1.4.0" "Command line tool for PostgreSQL server activity monitoring."
+.TH PG_ACTIVITY 1 "2018-10-02" "pg_activity 1.4.0" "Command line tool for PostgreSQL server activity monitoring."
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -142,6 +142,10 @@ pg_activity \- Realtime PostgreSQL database server monitoring tool
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
 Command line tool for PostgreSQL server activity monitoring.
+.PP
+pg_activity must run on the same server than the instance and
+as the user running the instance (or root) to show
+\&\s-1CPU, MEM, READ\s0 or \s-1WRITE\s0 columns and other system informations.
 .SH "COMMAND-LINE OPTIONS"
 .IX Header "COMMAND-LINE OPTIONS"
 .IP "\fB\-U \s-1USERNAME\s0\fR, \fB\-\-username=USERNAME\fR" 2
@@ -321,4 +325,6 @@ Command line tool for PostgreSQL server activity monitoring.
 .IX Header "EXAMPLES"
 PGPASSWORD='mypassword' pg_activity \-U pgadmin \-h 127.0.0.1 \-\-no\-client
 .PP
-pg_activity \-h /tmp
+pg_activity \-h /var/run/postgresql
+.PP
+pg_activity \-h myserver \-p 5433 \-d nagios \-U nagios

--- a/docs/man/pg_activity.pod
+++ b/docs/man/pg_activity.pod
@@ -10,6 +10,10 @@ B<pg_activity> [option..]
 
 Command line tool for PostgreSQL server activity monitoring.
 
+pg_activity must run on the same server than the instance and
+as the user running the instance (or root) to show
+CPU, MEM, READ or WRITE columns and other system informations.
+
 =head1 COMMAND-LINE OPTIONS
 
 =over 2
@@ -182,6 +186,8 @@ Command line tool for PostgreSQL server activity monitoring.
 
 PGPASSWORD='mypassword' pg_activity -U pgadmin -h 127.0.0.1 --no-client
 
-pg_activity -h /tmp
+pg_activity -h /var/run/postgresql
+
+pg_activity -h myserver -p 5433 -d nagios -U nagios
 
 =cut


### PR DESCRIPTION
Added a sentence in the man page for people like me that didn't read the README on github and didn't know that pg_activity could show system information, provided it runs as the right user.

Added an example, and updated the one with `-h /tmp` (not used anymore on Debian and RH since 9.4 at least).

I suppose that I had to run build-man.sh.