### PR TITLE
[IMP] new option to avoid total db sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Options
 		--rds                 Enable support for AWS RDS.
 		--help                Show this help message and exit.
 		--debug               Enable debug mode for traceback tracking.
+        --no-db-size          Skip total size of DB.
         
 
 	Display options, you can exclude some columns by using them :

--- a/pg_activity
+++ b/pg_activity
@@ -127,7 +127,7 @@ server activity monitoring.")
                 dest = 'rds',
                 action = 'store_true',
                 help = "Enable support for AWS RDS",
-                default = 'false')
+                default = False)
             group = OptionGroup(
                 parser,
                 "Display Options, you can exclude some columns by using them ")
@@ -138,6 +138,13 @@ server activity monitoring.")
                 action = 'store_true',
                 help = "Disable DATABASE.",
                 default = 'false')
+            # --no-db-size
+            group.add_option(
+                '--no-db-size',
+                dest = 'nodbsize',
+                action = 'store_true',
+                help = "Disable DATABASE size.",
+                default = False)
             # --no-user
             group.add_option(
                 '--no-user',
@@ -274,7 +281,7 @@ server activity monitoring.")
         disp_procs = None
         delta_disk_io = None
         # get DB informations
-        db_info = PGAUI.data.pg_get_db_info(None, using_rds = options.rds)
+        db_info = PGAUI.data.pg_get_db_info(None, using_rds=options.rds, skip_sizes=options.nodbsize)
         PGAUI.set_max_db_length(db_info['max_length'])
         # indentation
         indent = PGAUI.get_indent(flag)
@@ -301,7 +308,7 @@ server activity monitoring.")
                 delta_disk_io = PGAUI.data.get_global_io_counters()
             procs = new_procs
             # refresh the winodw
-            db_info = PGAUI.data.pg_get_db_info(db_info, using_rds = options.rds)
+            db_info = PGAUI.data.pg_get_db_info(db_info, using_rds=options.rds, skip_sizes=options.nodbsize)
             PGAUI.set_max_db_length(db_info['max_length'])
             # get active connections
             active_connections = PGAUI.data.pg_get_active_connections()


### PR DESCRIPTION
On clusters with thousands of databases, computing
total size of the cluster is painfull and make
pg_activity unusable. Don't compute the value make
pg_activity usable on those large clusters.