### PR TITLE
Add --output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options
 		-C, --no-color        Disable color usage.
 		--blocksize=BLOCKSIZE Filesystem blocksize (default: 4096).
 		--rds                 Enable support for AWS RDS.
+		--output=FILEPATH     Store running queries as CSV.
 		--help                Show this help message and exit.
 		--debug               Enable debug mode for traceback tracking.
 		--no-db-size          Skip total size of DB.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Options
     	--no-wait             Disable W.
     	--no-app-name         Disable App.
 
+
+Notes
+-----
+
+Length of SQL query text that pg_activity reports relies on PostgreSQL parameter `track_activity_query_size`. Default value is `1024` (expressed in bytes). If your SQL query text look truncated, you should increase `track_activity_query_size`.
+
+
 Interactives commands
 ---------------------
 

--- a/docs/man/pg_activity.1
+++ b/docs/man/pg_activity.1
@@ -183,6 +183,11 @@ as the user running the instance (or root) to show
 .Vb 1
 \&        Enable support for AWS RDS.
 .Ve
+.IP "\fB\-\-output=FILEPATH\fR" 2
+.IX Item "--output=FILEPATH"
+.Vb 1
+\&        Store running queries as CSV.
+.Ve
 .IP "\fB\-\-help\fR" 2
 .IX Item "--help"
 .Vb 1

--- a/docs/man/pg_activity.pod
+++ b/docs/man/pg_activity.pod
@@ -46,6 +46,10 @@ CPU, MEM, READ or WRITE columns and other system informations.
 
 	Enable support for AWS RDS.
 
+=item B<--output=FILEPATH>
+
+	Store running queries as CSV.
+
 =item B<--help>
 
 	Show this help message and exit.

--- a/pg_activity
+++ b/pg_activity
@@ -217,6 +217,13 @@ server activity monitoring.")
                 help = "Disable App.",
                 default = 'false')
             parser.add_option_group(group)
+            # --output
+            parser.add_option(
+                '--output',
+                dest = 'output',
+                help = "Store running queries as CSV.",
+                metavar = "FILEPATH",
+                default = None)
             # --help
             parser.add_option(
                 '--help',
@@ -276,6 +283,8 @@ server activity monitoring.")
         PGAUI.set_blocksize(int(options.blocksize))
         # verbose mode
         PGAUI.set_verbose_mode(int(options.verbosemode))
+        # output
+        PGAUI.set_output(options.output)
         # does pg_activity runing against local PG instance
         if not PGAUI.data.pg_is_local():
             PGAUI.set_is_local(False)


### PR DESCRIPTION
This new option defines a file path where to store running
queries/backends using CSV format. Default value is None, meaning the
feature is not active.
Running queries storage is working when pg_activity is on RUNNING
QUERIES tab only.

Fix #62 