### PR TITLE
New option to change queries display mode on start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ Options
 		--rds                 Enable support for AWS RDS.
 		--help                Show this help message and exit.
 		--debug               Enable debug mode for traceback tracking.
-        --no-db-size          Skip total size of DB.
+		--no-db-size          Skip total size of DB.
+		--verbose-mode=VERBOSE_MODE
+                               Queries display mode. Values: 1-TRUNCATED, 2-FULL(default), 3-INDENTED
 
 
 	Display options, you can exclude some columns by using them :
-		--no-database         Disable DATABASE.
+    	--no-database         Disable DATABASE.
     	--no-user             Disable USER.
     	--no-client           Disable CLIENT.
     	--no-cpu              Disable CPU%.

--- a/pg_activity
+++ b/pg_activity
@@ -128,6 +128,14 @@ server activity monitoring.")
                 action = 'store_true',
                 help = "Enable support for AWS RDS",
                 default = False)
+            # --verbose-mode
+            parser.add_option(
+                '--verbose-mode',
+                dest = 'verbosemode',
+                help = "Queries display mode. Values: 1-TRUNCATED, 2-FULL(default), 3-INDENTED",
+                metavar = 'VERBOSE_MODE',
+                choices = ['1', '2', '3'],
+                default = '2')
             group = OptionGroup(
                 parser,
                 "Display Options, you can exclude some columns by using them ")
@@ -266,6 +274,8 @@ server activity monitoring.")
         PGAUI.set_max_db_length(16)
         # blocksize
         PGAUI.set_blocksize(int(options.blocksize))
+        # verbose mode
+        PGAUI.set_verbose_mode(int(options.verbosemode))
         # does pg_activity runing against local PG instance
         if not PGAUI.data.pg_is_local():
             PGAUI.set_is_local(False)

--- a/pgactivity/UI.py
+++ b/pgactivity/UI.py
@@ -391,6 +391,18 @@ class UI:
         # Init curses
         # self.__init_curses()
 
+    def set_verbose_mode(self, verbose_mode):
+        """
+        Set self.verbose_mode
+        """
+        self.verbose_mode = verbose_mode
+
+    def get_verbose_mode(self,):
+        """
+        Get self.verbose_mode
+        """
+        return self.verbose_mode
+
     def set_is_local(self, is_local):
         """
         Set self.is_local


### PR DESCRIPTION
Often we do not want to see the queries in full mode. We want to monitor other information, such as TIME +, CPU%, MEM%, READs and WRITEs. This option enables you to initialize pg_activity in the most compact format of queries.