### PR TITLE
Adding refresh dbsize interative action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pgactivity/__pycache__/
+.vscode

--- a/README.md
+++ b/README.md
@@ -82,25 +82,26 @@ Length of SQL query text that pg_activity reports relies on PostgreSQL parameter
 Interactives commands
 ---------------------
 
-| Key       | Action                                                 |
-|-----------|--------------------------------------------------------|
-| `C`       | Activate/deactivate colors                             |
-| `r`       | Sort by READ/s, descending                             |
-| `w`       | Sort by WRITE/s, descending                            |
-| `c`       | Sort by CPU%, descending                               |
-| `m`       | Sort by MEM%, descending                               |
-| `t`       | Sort by TIME+, descending                              |
-| `Space`   | Pause on/off                                           |
-| `v`       | Change queries display mode: full, truncated, indented |
-| `UP/DOWN` | Scroll processes list                                  |
-| `q`       | Quit                                                   |
-| `+`       | Increase refresh time. Maximum value : 3s              |
-| `-`       | Decrease refresh time. Minimum Value : 1s              |
-| `F1/1`    | Running queries list                                   |
-| `F2/2`    | Waiting queries list                                   |
-| `F3/3`    | Blocking queries list                                  |
-| `h`       | Help page                                              |
-| `R`       | Refresh                                                |
+| Key       | Action                                                           |
+|-----------|------------------------------------------------------------------|
+| `C`       | Activate/deactivate colors                                       |
+| `r`       | Sort by READ/s, descending                                       |
+| `w`       | Sort by WRITE/s, descending                                      |
+| `c`       | Sort by CPU%, descending                                         |
+| `m`       | Sort by MEM%, descending                                         |
+| `t`       | Sort by TIME+, descending                                        |
+| `Space`   | Pause on/off                                                     |
+| `v`       | Change queries display mode: full, truncated, indented           |
+| `UP/DOWN` | Scroll processes list                                            |
+| `q`       | Quit                                                             |
+| `+`       | Increase refresh time. Maximum value : 3s                        |
+| `-`       | Decrease refresh time. Minimum Value : 1s                        |
+| `F1/1`    | Running queries list                                             |
+| `F2/2`    | Waiting queries list                                             |
+| `F3/3`    | Blocking queries list                                            |
+| `h`       | Help page                                                        |
+| `R`       | Refresh                                                          |
+| `D`       | Refresh Database Size (including when --no-dbzise option applied)|
 
 Navigation mode
 ---------------

--- a/docs/man/pg_activity.1
+++ b/docs/man/pg_activity.1
@@ -324,6 +324,8 @@ as the user running the instance (or root) to show
 .IX Item "h Help page."
 .IP "\fBR\fR     Refresh." 2
 .IX Item "R Refresh."
+.IP "\fBR\fR     Refresh database size." 2
+.IX Item "D Refresh database size."
 .PD
 .SH "NAVIGATION MODE"
 .IX Header "NAVIGATION MODE"

--- a/docs/man/pg_activity.pod
+++ b/docs/man/pg_activity.pod
@@ -178,6 +178,8 @@ CPU, MEM, READ or WRITE columns and other system informations.
 
 =item B<R>     Refresh.
 
+=item B<D>     Refresh database size.
+
 =back
 
 =head1 NAVIGATION MODE

--- a/pg_activity
+++ b/pg_activity
@@ -313,12 +313,13 @@ server activity monitoring.")
                 if PGAUI.get_is_local():
                     delta_disk_io = PGAUI.data.get_global_io_counters()
                 procs = new_procs
-                # refresh the winodw
+                # refresh the window
                 db_info = PGAUI.data.pg_get_db_info(
                     db_info,
                     using_rds=options.rds,
                     skip_sizes=options.nodbsize
-                )
+                ) 
+                PGAUI.data.set_refresh_dbsize(False)
                 PGAUI.set_max_db_length(db_info['max_length'])
                 # get active connections
                 active_connections = PGAUI.data.pg_get_active_connections()

--- a/pgactivity/UI.py
+++ b/pgactivity/UI.py
@@ -1250,6 +1250,11 @@ class UI:
         if key == ord('R'):
             known = True
 
+        # Refresh db size
+        if key == ord('D'):
+            self.data.set_refresh_dbsize(True)
+            do_refresh = True
+
         if key == ord('u'):
             self.__empty_pid_yank()
             known = True
@@ -1874,6 +1879,12 @@ class UI:
                 00,
                 "      R",
                 "force refresh")
+        self.lineno += 1
+        self.__display_help_key(
+                self.lineno,
+                00,
+                "      D",
+                "force refresh database size")
         self.lineno += 1
         self.__print_string(
                 self.lineno,


### PR DESCRIPTION
764/5000
Hello Lulien. I really loved the option --no-dbsize. It's something I was already thinking of implementing because I was having load problems due to the high cost of the query. Since its availability, I have always used it, but many times I have wanted to see what the current size of the base is. I needed to run another instance of pg_activity without the --no-dbsize option only to see the size of the base and just after closing it. I then created an interactive option for this, using the "D" to signal the refresh. I'm not a python programmer, so I don't know if I did it the best way. Feel free to perform any refactorings you deem appropriate. Thank you in advance for accepting my pull request. It's really very enjoyable for me to contribute to this very cool project.